### PR TITLE
Fix bug by empty response from SOAP

### DIFF
--- a/src/RegonSoapClient.php
+++ b/src/RegonSoapClient.php
@@ -74,10 +74,12 @@ class RegonSoapClient extends SoapClient
         $hdr->appendChild(new DOMElement('To', $location, 'http://www.w3.org/2005/08/addressing'));
         $dom->documentElement->insertBefore($hdr, $dom->documentElement->firstChild);
         $request  = $dom->saveXML();
-        $response = parent::__doRequest($request, $location, $action, $version, $oneWay);
-        $response = stristr(stristr($response, '<s:'), '</s:Envelope>', true) . '</s:Envelope>';
+        if ($response = parent::__doRequest($request, $location, $action, $version, $oneWay)) {
+            $response = stristr(stristr($response, '<s:'), '</s:Envelope>', true) . '</s:Envelope>';
+            return $response;
+        }
 
-        return $response;
+        return '';
     }
 
     /**


### PR DESCRIPTION
 stristr(): Argument #1 ($haystack) must be of type string, null given

  at domains/______.pl/public_html/vendor/mrcnpdlk/regon-api/src/RegonSoapClient.php:78
     74▕         $hdr->appendChild(new DOMElement('To', $location, 'http://www.w3.org/2005/08/addressing'));
     75▕         $dom->documentElement->insertBefore($hdr, $dom->documentElement->firstChild);
     76▕         $request  = $dom->saveXML();
     77▕         $response = parent::__doRequest($request, $location, $action, $version, $oneWay);
  ➜  78▕         $response = stristr(stristr($response, '<s:'), '</s:Envelope>', true) . '</s:Envelope>';
     79▕ 
     80▕         return $response;
     81▕     }
     82▕